### PR TITLE
Add data cleanup actions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,9 +34,12 @@
       </section>
 
       <section class="bg-white shadow-xl rounded-2xl p-6 mb-8">
-        <div class="flex justify-between items-center mb-4">
+        <div class="flex flex-wrap gap-2 justify-between items-center mb-4">
           <h2 class="text-xl font-semibold text-sky-700">Graphique du Débit</h2>
-          <button id="downloadCSV" class="bg-sky-600 text-white px-4 py-2 rounded hover:bg-sky-700 transition">📄 Export CSV</button>
+          <div class="flex gap-2">
+            <button id="downloadCSV" class="bg-sky-600 text-white px-4 py-2 rounded hover:bg-sky-700 transition">📄 Export CSV</button>
+            <button id="clearOld" class="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition">🗑️ Nettoyer (>7j)</button>
+          </div>
         </div>
         <canvas id="speedChart" height="100"></canvas>
       </section>
@@ -50,6 +53,7 @@
                 <th class="px-4 py-2">Horodatage</th>
                 <th class="px-4 py-2">Débit (Mbps)</th>
                 <th class="px-4 py-2">État</th>
+                <th class="px-4 py-2">Action</th>
               </tr>
             </thead>
             <tbody id="dataTable" class="text-gray-700 divide-y divide-gray-200">
@@ -120,6 +124,9 @@
                   <td class="px-4 py-2">
                     <span class="px-2 py-1 rounded-full text-sm font-medium ${badgeClass}">${label}</span>
                   </td>
+                  <td class="px-4 py-2 text-right">
+                    <button data-ts="${d.timestamp}" class="delete-entry text-red-600 hover:underline">Supprimer</button>
+                  </td>
                 </tr>`;
             })
             .join('');
@@ -165,6 +172,16 @@
       }
 
       document.getElementById('downloadCSV').addEventListener('click', downloadCSV);
+      document.getElementById('clearOld').addEventListener('click', async () => {
+        await fetch('/api/data/old', { method: 'DELETE' });
+        updateData();
+      });
+
+      $(document).on('click', '.delete-entry', async function() {
+        const ts = $(this).data('ts');
+        await fetch(`/api/data/${ts}`, { method: 'DELETE' });
+        updateData();
+      });
       setInterval(updateData, 5000);
       updateData();
     </script>

--- a/server.mjs
+++ b/server.mjs
@@ -5,6 +5,7 @@ import { runTest } from './index.mjs';
 
 const app = express();
 const PORT = 5000;
+app.use(express.json());
 
 app.use(express.static('public'));
 
@@ -23,6 +24,44 @@ app.get('/api/data', (req, res) => {
     }
   }
   res.json(dataArr);
+});
+
+// Supprimer les entrées plus anciennes que 7 jours
+app.delete('/api/data/old', (req, res) => {
+  const limit = Date.now() - 7 * 24 * 60 * 60 * 1000; // 7 jours en ms
+  let dataArr = [];
+  if (fs.existsSync('./data.json')) {
+    try {
+      const content = fs.readFileSync('./data.json');
+      if (content.length > 0) {
+        dataArr = JSON.parse(content);
+      }
+    } catch (err) {
+      console.error('Erreur lecture JSON : ', err.message);
+    }
+  }
+  const filtered = dataArr.filter(entry => new Date(entry.timestamp).getTime() >= limit);
+  fs.writeFileSync('./data.json', JSON.stringify(filtered, null, 2));
+  res.json({ removed: dataArr.length - filtered.length });
+});
+
+// Supprimer une entrée spécifique (par timestamp)
+app.delete('/api/data/:timestamp', (req, res) => {
+  const { timestamp } = req.params;
+  let dataArr = [];
+  if (fs.existsSync('./data.json')) {
+    try {
+      const content = fs.readFileSync('./data.json');
+      if (content.length > 0) {
+        dataArr = JSON.parse(content);
+      }
+    } catch (err) {
+      console.error('Erreur lecture JSON : ', err.message);
+    }
+  }
+  const filtered = dataArr.filter(entry => entry.timestamp !== timestamp);
+  fs.writeFileSync('./data.json', JSON.stringify(filtered, null, 2));
+  res.json({ removed: dataArr.length - filtered.length });
 });
 
 // Page principale


### PR DESCRIPTION
## Summary
- add new endpoint to clean entries older than 7 days and delete by timestamp
- add UI buttons to export CSV, clear old data and delete individual entries
- include Tailwind-based improvements for action buttons

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863a5d392d083319f2e3d74b2025dfe