### PR TITLE
Add manual test button and JSON export

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ docker run -p 5000:5000 pinger
 ## Fonctionnement
 
 Un test de débit est effectué au démarrage puis toutes les minutes. Les mesures sont enregistrées dans `data.json` et présentées sous forme de graphique, de tableau et de statistiques.
+
+Vous pouvez lancer un test manuel via le bouton **"Tester maintenant"** de l'interface et exporter les résultats au format CSV ou JSON.

--- a/index.mjs
+++ b/index.mjs
@@ -96,7 +96,10 @@ export async function runTest() {
     if (dataArr.length > 500) dataArr = dataArr.slice(-500); // limite à 500 entrées
 
     fs.writeFileSync(dataPath, JSON.stringify(dataArr, null, 2));
+
+    return result;
   } catch (error) {
     console.error("❌ Test échoué : ", error.message);
+    return null;
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -36,8 +36,10 @@
       <section class="bg-white shadow-xl rounded-2xl p-6 mb-8">
         <div class="flex flex-wrap gap-2 justify-between items-center mb-4">
           <h2 class="text-xl font-semibold text-sky-700">Graphique du Débit</h2>
-          <div class="flex gap-2">
+          <div class="flex flex-wrap gap-2">
+            <button id="testNow" class="bg-sky-600 text-white px-4 py-2 rounded hover:bg-sky-700 transition">🚀 Tester maintenant</button>
             <button id="downloadCSV" class="bg-sky-600 text-white px-4 py-2 rounded hover:bg-sky-700 transition">📄 Export CSV</button>
+            <button id="downloadJSON" class="bg-sky-600 text-white px-4 py-2 rounded hover:bg-sky-700 transition">📁 Export JSON</button>
             <button id="clearOld" class="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition">🗑️ Nettoyer (>7j)</button>
           </div>
         </div>
@@ -171,7 +173,21 @@
         link.click();
       }
 
+      function downloadJSON() {
+        const blob = new Blob([JSON.stringify(currentData, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.setAttribute('href', url);
+        link.setAttribute('download', 'statistiques_debit.json');
+        link.click();
+      }
+
       document.getElementById('downloadCSV').addEventListener('click', downloadCSV);
+      document.getElementById('downloadJSON').addEventListener('click', downloadJSON);
+      document.getElementById('testNow').addEventListener('click', async () => {
+        await fetch('/api/test', { method: 'POST' });
+        updateData();
+      });
       document.getElementById('clearOld').addEventListener('click', async () => {
         await fetch('/api/data/old', { method: 'DELETE' });
         updateData();

--- a/server.mjs
+++ b/server.mjs
@@ -64,6 +64,16 @@ app.delete('/api/data/:timestamp', (req, res) => {
   res.json({ removed: dataArr.length - filtered.length });
 });
 
+// Lancer un test de débit à la demande
+app.post('/api/test', async (req, res) => {
+  const result = await runTest();
+  if (result) {
+    res.json(result);
+  } else {
+    res.status(500).json({ error: 'Test échoué' });
+  }
+});
+
 // Page principale
 app.get('/', (req, res) => {
   res.sendFile(path.resolve('./public/index.html'));


### PR DESCRIPTION
## Summary
- allow `runTest` to return the measured speed
- add API endpoint to trigger a manual speed test
- extend the dashboard with buttons to run a test and export JSON
- document new features in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863a85d3d9083319a82d95464af80c3