### PR TITLE
Add docker compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install --production
 COPY . .
+ENV PORT=5000
 EXPOSE 5000
 CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ Pour lancer l'application dans un conteneur Docker :
 
 ```bash
 docker build -t pinger .
-docker run -p 5000:5000 pinger
+docker run -p 5000:5000 -e PORT=5000 pinger
+```
+
+Vous pouvez également utiliser **docker-compose** pour faciliter le
+démarrage :
+
+```bash
+docker compose up
 ```
 
 ## Fonctionnement

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  pinger:
+    build: .
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./data.json:/app/data.json
+

--- a/server.mjs
+++ b/server.mjs
@@ -4,7 +4,8 @@ import path from 'path';
 import { runTest } from './index.mjs';
 
 const app = express();
-const PORT = 5000;
+// Allow overriding the port via environment variable when running in Docker
+const PORT = process.env.PORT || 5000;
 app.use(express.json());
 
 app.use(express.static('public'));


### PR DESCRIPTION
## Summary
- allow setting PORT via env var
- embed PORT variable in Dockerfile
- add docker-compose config
- document docker compose in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6863aaf522e88331b348988685d58c5b