### PR TITLE
Add local speedtest feature

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,10 +40,17 @@
             <button id="testNow" class="bg-sky-600 text-white px-4 py-2 rounded hover:bg-sky-700 transition">🚀 Tester maintenant</button>
             <button id="downloadCSV" class="bg-sky-600 text-white px-4 py-2 rounded hover:bg-sky-700 transition">📄 Export CSV</button>
             <button id="downloadJSON" class="bg-sky-600 text-white px-4 py-2 rounded hover:bg-sky-700 transition">📁 Export JSON</button>
+            <button id="localTestBtn" class="bg-sky-600 text-white px-4 py-2 rounded hover:bg-sky-700 transition">⚡ Test local</button>
             <button id="clearOld" class="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition">🗑️ Nettoyer (>7j)</button>
           </div>
         </div>
         <canvas id="speedChart" height="100"></canvas>
+      </section>
+
+      <section id="localTestSection" class="bg-white shadow-xl rounded-2xl p-6 mb-8 hidden">
+        <h2 class="text-xl font-semibold text-sky-700 mb-4">Résultat Speedtest Local</h2>
+        <p>Ping : <span id="localPing">--</span> ms</p>
+        <p>Débit : <span id="localSpeed">--</span> Mbps</p>
       </section>
 
       <section class="bg-white shadow-xl rounded-2xl p-6">
@@ -182,12 +189,35 @@
         link.click();
       }
 
+      async function runLocalTest() {
+        document.getElementById('localTestSection').classList.remove('hidden');
+        document.getElementById('localPing').textContent = '--';
+        document.getElementById('localSpeed').textContent = '--';
+
+        const start = performance.now();
+        const response = await fetch('/speedtest-file');
+        const ping = performance.now() - start;
+        document.getElementById('localPing').textContent = Math.round(ping);
+
+        const reader = response.body.getReader();
+        let received = 0;
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          received += value.length;
+          const elapsed = (performance.now() - start) / 1000;
+          const speed = (received * 8 / 1e6) / elapsed;
+          document.getElementById('localSpeed').textContent = Math.round(speed);
+        }
+      }
+
       document.getElementById('downloadCSV').addEventListener('click', downloadCSV);
       document.getElementById('downloadJSON').addEventListener('click', downloadJSON);
       document.getElementById('testNow').addEventListener('click', async () => {
         await fetch('/api/test', { method: 'POST' });
         updateData();
       });
+      document.getElementById('localTestBtn').addEventListener('click', runLocalTest);
       document.getElementById('clearOld').addEventListener('click', async () => {
         await fetch('/api/data/old', { method: 'DELETE' });
         updateData();

--- a/server.mjs
+++ b/server.mjs
@@ -1,6 +1,7 @@
 import express from 'express';
 import fs from 'fs';
 import path from 'path';
+import { Readable } from 'stream';
 import { runTest } from './index.mjs';
 
 const app = express();
@@ -9,6 +10,27 @@ const PORT = process.env.PORT || 5000;
 app.use(express.json());
 
 app.use(express.static('public'));
+
+// Fichier de test de débit (~40MB)
+app.get('/speedtest-file', (req, res) => {
+  const size = 40 * 1024 * 1024; // 40MB
+  res.setHeader('Content-Type', 'application/octet-stream');
+  res.setHeader('Content-Disposition', 'attachment; filename="speedtest.bin"');
+
+  const chunkSize = 64 * 1024;
+  let sent = 0;
+  const stream = new Readable({
+    read() {
+      if (sent >= size) {
+        this.push(null);
+      } else {
+        sent += chunkSize;
+        this.push(Buffer.alloc(chunkSize));
+      }
+    }
+  });
+  stream.pipe(res);
+});
 
 
 // API pour récupérer les données


### PR DESCRIPTION
## Summary
- add a streaming `/speedtest-file` endpoint serving ~40MB
- expose a "Test local" button in the UI
- implement front-end speed measurement using the new endpoint

## Testing
- `npm start` *(fails: Request failed with status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_6863b7bcbc988331b58566ab37923d36